### PR TITLE
fix: do not setup backend if it is misconfigured

### DIFF
--- a/api/logs/logs.go
+++ b/api/logs/logs.go
@@ -42,6 +42,10 @@ type SearchBackend struct {
 type Routes []SearchRoute
 
 func (t Routes) MatchRoute(q *SearchParams) (match bool, isAdditive bool) {
+	// If routes are empty, always return true
+	if len(t) == 0 {
+		return true, false
+	}
 	for _, route := range t {
 		if route.Match(q) {
 			return true, route.IsAdditive

--- a/api/logs/logs.go
+++ b/api/logs/logs.go
@@ -42,10 +42,6 @@ type SearchBackend struct {
 type Routes []SearchRoute
 
 func (t Routes) MatchRoute(q *SearchParams) (match bool, isAdditive bool) {
-	// If routes are empty, always return true
-	if len(t) == 0 {
-		return true, false
-	}
 	for _, route := range t {
 		if route.Match(q) {
 			return true, route.IsAdditive

--- a/chart/templates/logging-backends.yaml
+++ b/chart/templates/logging-backends.yaml
@@ -5,6 +5,6 @@ metadata:
 spec:
   backends:
   - kubernetes:
-      kubeconfig: {}
       routes:
-        - idPrefix: ''
+      - type: KubernetesPod
+      - type: KubernetesNode

--- a/chart/templates/logging-backends.yaml
+++ b/chart/templates/logging-backends.yaml
@@ -1,0 +1,10 @@
+apiVersion: apm-hub.flanksource.com/v1
+kind: LoggingBackend
+metadata:
+  name: kubernetes
+spec:
+  backends:
+  - kubernetes:
+      kubeconfig: {}
+      routes:
+        - idPrefix: ''

--- a/db/logging_backend.go
+++ b/db/logging_backend.go
@@ -63,7 +63,7 @@ func GetLoggingBackendsSpecs() ([]logs.SearchBackendConfig, error) {
 		var spec apiv1.LoggingBackendSpec
 		err := json.Unmarshal([]byte(dbBackend.Spec), &spec)
 		if err != nil {
-			logger.Errorf("")
+			logger.Errorf("failed to marshall backend spec:%s due to error:%v", dbBackend.ID, err)
 			continue
 		}
 

--- a/pkg/config.go
+++ b/pkg/config.go
@@ -37,19 +37,18 @@ func ParseConfig(configFile string) (*logs.SearchConfig, error) {
 }
 
 // SetupBackends instantiates backends from the given configurations.
-func SetupBackends(kommonsClient *kommons.Client, backendConfigs []logs.SearchBackendConfig) ([]logs.SearchBackend, error) {
+func SetupBackends(kommonsClient *kommons.Client, backendConfigs []logs.SearchBackendConfig) []logs.SearchBackend {
 	var allBackends []logs.SearchBackend
 	for _, config := range backendConfigs {
 		backends, err := getBackendsFromConfigs(kommonsClient, config)
 		if err != nil {
-			logger.Errorf("error instantiating backends from the config: %v", err)
+			logger.Errorf("error instantiating backend from the config: %v", err)
 			continue
 		}
 
 		allBackends = append(allBackends, backends...)
 	}
-
-	return allBackends, nil
+	return allBackends
 }
 
 func LoadGlobalBackends() error {
@@ -63,12 +62,7 @@ func LoadGlobalBackends() error {
 		return fmt.Errorf("error getting the logging backend configs from the db: %w", err)
 	}
 
-	backends, err := SetupBackends(kommonsClient, dbBackendConfigs)
-	if err != nil {
-		return fmt.Errorf("error setting up the backends: %w", err)
-	}
-
-	logs.GlobalBackends = backends
+	logs.GlobalBackends = SetupBackends(kommonsClient, dbBackendConfigs)
 	return nil
 }
 

--- a/pkg/config.go
+++ b/pkg/config.go
@@ -72,6 +72,8 @@ func LoadGlobalBackends() error {
 	return nil
 }
 
+var errRoutesNotProvided = fmt.Errorf("no routes provided")
+
 // getBackendsFromConfigs instantiates backends from the given configuration.
 //
 // A single configuration can have multiple backends.
@@ -79,6 +81,10 @@ func getBackendsFromConfigs(kommonsClient *kommons.Client, backendConfig logs.Se
 	var backends []logs.SearchBackend
 
 	if backendConfig.Kubernetes != nil {
+		if len(backendConfig.Kubernetes.Routes) == 0 {
+			return nil, errRoutesNotProvided
+		}
+
 		k8sclient, err := k8s.GetKubeClient(kommonsClient, backendConfig.Kubernetes)
 		if err != nil {
 			return nil, err
@@ -89,6 +95,10 @@ func getBackendsFromConfigs(kommonsClient *kommons.Client, backendConfig logs.Se
 	}
 
 	if backendConfig.File != nil {
+		if len(backendConfig.File.Routes) == 0 {
+			return nil, errRoutesNotProvided
+		}
+
 		// If the paths are not absolute,
 		// They should be parsed with respect to the current path
 		for j, p := range backendConfig.File.Paths {
@@ -103,6 +113,10 @@ func getBackendsFromConfigs(kommonsClient *kommons.Client, backendConfig logs.Se
 	}
 
 	if backendConfig.ElasticSearch != nil {
+		if len(backendConfig.ElasticSearch.Routes) == 0 {
+			return nil, errRoutesNotProvided
+		}
+
 		cfg, err := getElasticConfig(kommonsClient, backendConfig.ElasticSearch)
 		if err != nil {
 			return nil, fmt.Errorf("error getting the elastic search config: %w", err)
@@ -132,6 +146,10 @@ func getBackendsFromConfigs(kommonsClient *kommons.Client, backendConfig logs.Se
 	}
 
 	if backendConfig.OpenSearch != nil {
+		if len(backendConfig.OpenSearch.Routes) == 0 {
+			return nil, errRoutesNotProvided
+		}
+
 		cfg, err := getOpenSearchConfig(kommonsClient, backendConfig.OpenSearch)
 		if err != nil {
 			return nil, fmt.Errorf("error getting the openSearch config: %w", err)


### PR DESCRIPTION
Without a length check, match route always returned false resulting in empty responses